### PR TITLE
Add ESBuild for transpiling sources

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douglasneuroinformatics/nestjs",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "NestJS Core",
   "license": "LGPL-3.0",
   "type": "module",
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && bun build:js && bun build:ts",
-    "build:js": "esbuild --bundle --format=esm --outdir=dist --packages=external --platform=node --sourcemap=external  src/index.ts",
+    "build:js": "bunx esbuild --bundle --format=esm --outdir=dist --packages=external --platform=node --sourcemap=external  src/core/index.ts src/modules/index.ts src/testing/index.ts",
     "build:ts": "tsc -b tsconfig.build.json",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -22,7 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -b tsconfig.build.json",
+    "build": "rm -rf dist && bun build:js && bun build:ts",
+    "build:js": "esbuild --bundle --format=esm --outdir=dist --packages=external --platform=node --sourcemap=external  src/index.ts",
+    "build:ts": "tsc -b tsconfig.build.json",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",
     "push": "bun run lint && bun test && bun run build && npm publish"

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -1,3 +1,0 @@
-export * from './core';
-export * from './modules';
-export * from './testing';

--- a/packages/nestjs/tsconfig.build.json
+++ b/packages/nestjs/tsconfig.build.json
@@ -2,9 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "noEmit": false,
-    "outDir": "dist",
-    "sourceMap": true
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts"]

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -14,7 +14,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -b tsconfig.build.json",
+    "build": "rm -rf dist && bun build:js && bun build:ts",
+    "build:js": "esbuild --bundle --format=esm --outdir=dist --packages=external --platform=neutral --sourcemap=external  src/index.ts",
+    "build:ts": "tsc -b tsconfig.build.json",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",
     "push": "bun run lint && bun test && bun run build && npm publish"

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douglasneuroinformatics/stats",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Very basic statistics",
   "license": "LGPL-3.0",
   "type": "module",

--- a/packages/stats/tsconfig.build.json
+++ b/packages/stats/tsconfig.build.json
@@ -2,9 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "noEmit": false,
-    "outDir": "dist",
-    "sourceMap": true
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts"]

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douglasneuroinformatics/ui",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Common React components and tailwind config for DNP projects",
   "license": "LGPL-3.0",
   "type": "module",
@@ -16,8 +16,9 @@
     "tailwind.config.cjs"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -b tsconfig.build.json",
-    "build:storybook": "storybook build",
+    "build": "rm -rf dist && bun build:js && bun build:ts",
+    "build:js": "esbuild --bundle --format=esm --outdir=dist --packages=external --platform=browser --sourcemap=external  src/index.ts",
+    "build:ts": "tsc -b tsconfig.build.json",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",
     "push": "bun run lint && bun run build && npm publish",

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "jsx": "preserve",
+    "emitDeclarationOnly": true,
     "noEmit": false,
     "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true
+    "rootDir": "src"
   },
   "exclude": ["**/*.stories.tsx"],
   "extends": "./tsconfig.json",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -b tsconfig.build.json",
+    "build": "rm -rf dist && bun build:js && bun build:ts",
+    "build:js": "esbuild --bundle --format=esm --outdir=dist --packages=external --platform=neutral --sourcemap=external  src/index.ts",
+    "build:ts": "tsc -b tsconfig.build.json",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",
     "push": "bun run lint && bun test && bun run build && npm publish"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douglasneuroinformatics/utils",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A collection of zero dependency JavaScript utility functions for Node.js and the browser",
   "license": "LGPL-3.0",
   "type": "module",

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -2,9 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "noEmit": false,
-    "outDir": "dist",
-    "sourceMap": true
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
Unfortunately, we need to apply an additional build tool, since the bundler resolution strategy does not include file extensions, typescript refuses to add them on compilation, and node insists on requiring them with ES module format. 