### PR TITLE
Add encryption methods to `CryptoService`

### DIFF
--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @douglasneuroinformatics/nestjs
 
+## 2.2.0
+
+### Minor Changes
+
+- Added encryption methods to `CryptoService`
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douglasneuroinformatics/nestjs",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "NestJS Core",
   "license": "LGPL-3.0",
   "type": "module",

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from '..';
+import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions, EncryptedData } from '..';
 import { CryptoService } from '../crypto.service';
 
 describe('CryptoService', () => {
@@ -76,9 +76,9 @@ describe('CryptoService', () => {
       privateKey = keyPair.privateKey;
     });
 
-    it('encrypt should return Buffer', async () => {
+    it('encrypt should return an instance of EncryptedData', async () => {
       const encrypted = await cryptoService.encrypt(originalText, publicKey);
-      expect(encrypted).toBeInstanceOf(Buffer);
+      expect(encrypted).toBeInstanceOf(EncryptedData);
     });
 
     it('decrypt should return original text', async () => {

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -55,4 +55,42 @@ describe('CryptoService', () => {
       expect(cryptoService.comparePassword('bar', hash)).resolves.toBeFalse();
     });
   });
+
+  describe('generateKeyPair', () => {
+    it('should generate a key pair with private and public keys', async () => {
+      const keyPair = await cryptoService.generateKeyPair();
+      expect(keyPair).toHaveProperty('privateKey');
+      expect(keyPair).toHaveProperty('publicKey');
+      expect(keyPair.privateKey).toBeInstanceOf(CryptoKey);
+      expect(keyPair.publicKey).toBeInstanceOf(CryptoKey);
+    });
+  });
+
+  describe('encrypt and decrypt', () => {
+    const originalText = 'Hello World';
+    let publicKey: CryptoKey, privateKey: CryptoKey;
+
+    beforeEach(async () => {
+      const keyPair = await cryptoService.generateKeyPair();
+      publicKey = keyPair.publicKey;
+      privateKey = keyPair.privateKey;
+    });
+
+    it('encrypt should return ArrayBuffer', async () => {
+      const encrypted = await cryptoService.encrypt(originalText, publicKey);
+      expect(encrypted).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it('decrypt should return original text', async () => {
+      const encrypted = await cryptoService.encrypt(originalText, publicKey);
+      const decrypted = await cryptoService.decrypt(encrypted, privateKey);
+      expect(decrypted).toBe(originalText);
+    });
+
+    it('decrypt with incorrect private key should fail', async () => {
+      const encrypted = await cryptoService.encrypt(originalText, publicKey);
+      const keyPair = await cryptoService.generateKeyPair();
+      expect(cryptoService.decrypt(encrypted, keyPair.privateKey)).rejects.toThrow();
+    });
+  });
 });

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -67,7 +67,7 @@ describe('CryptoService', () => {
   });
 
   describe('encrypt and decrypt', () => {
-    const originalText = 'Hello World';
+    const originalText = 'Cela devrait fonctionner avec les caractères unicode 😃';
     let publicKey: CryptoKey, privateKey: CryptoKey;
 
     beforeEach(async () => {

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -76,9 +76,9 @@ describe('CryptoService', () => {
       privateKey = keyPair.privateKey;
     });
 
-    it('encrypt should return ArrayBuffer', async () => {
+    it('encrypt should return Buffer', async () => {
       const encrypted = await cryptoService.encrypt(originalText, publicKey);
-      expect(encrypted).toBeInstanceOf(ArrayBuffer);
+      expect(encrypted).toBeInstanceOf(Buffer);
     });
 
     it('decrypt should return original text', async () => {

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -17,13 +17,13 @@ export class CryptoService {
   }
 
   /**
-   * Decrypts an ArrayBuffer using the provided private key.
+   * Decrypts an Buffer using the provided private key.
    *
    * @param buffer - The data to be decrypted.
    * @param privateKey - The private key to be used for decryption.
    * @returns A promise that resolves to the decrypted string.
    */
-  async decrypt(buffer: ArrayBuffer, privateKey: CryptoKey): Promise<string> {
+  async decrypt(buffer: Buffer, privateKey: CryptoKey): Promise<string> {
     const decrypted = await crypto.webcrypto.subtle.decrypt(
       {
         name: 'RSA-OAEP'
@@ -35,21 +35,22 @@ export class CryptoService {
   }
 
   /**
-   * Encrypts a text string using the provided public key.
+   * Encrypts a string using the provided public key.
    *
    * @param text - The text to be encrypted.
    * @param publicKey - The public key to be used for encryption.
-   * @return A promise that resolves to the encrypted data in ArrayBuffer format.
+   * @return A promise that resolves to the encrypted data in Buffer format.
    */
-  async encrypt(text: string, publicKey: CryptoKey): Promise<ArrayBuffer> {
+  async encrypt(text: string, publicKey: CryptoKey): Promise<Buffer> {
     const encoded = this.textEncoder.encode(text);
-    return crypto.webcrypto.subtle.encrypt(
+    const arrayBuffer = await crypto.webcrypto.subtle.encrypt(
       {
         name: 'RSA-OAEP'
       },
       publicKey,
       encoded
     );
+    return Buffer.from(arrayBuffer);
   }
 
   /**

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -7,10 +7,69 @@ import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from './crypto.
 
 @Injectable()
 export class CryptoService {
+  private textDecoder = new TextDecoder();
+  private textEncoder = new TextEncoder();
+
   constructor(@Inject(CRYPTO_MODULE_OPTIONS_TOKEN) private readonly options: CryptoModuleOptions) {}
 
   async comparePassword(password: string, hash: string) {
     return Bun.password.verify(password, hash);
+  }
+
+  /**
+   * Decrypts an ArrayBuffer using the provided private key.
+   *
+   * @param buffer - The data to be decrypted.
+   * @param privateKey - The private key to be used for decryption.
+   * @returns A promise that resolves to the decrypted string.
+   */
+  async decrypt(buffer: ArrayBuffer, privateKey: CryptoKey): Promise<string> {
+    const decrypted = await crypto.webcrypto.subtle.decrypt(
+      {
+        name: 'RSA-OAEP'
+      },
+      privateKey,
+      buffer
+    );
+    return this.textDecoder.decode(decrypted);
+  }
+
+  /**
+   * Encrypts a text string using the provided public key.
+   *
+   * @param text - The text to be encrypted.
+   * @param publicKey - The public key to be used for encryption.
+   * @return A promise that resolves to the encrypted data in ArrayBuffer format.
+   */
+  async encrypt(text: string, publicKey: CryptoKey): Promise<ArrayBuffer> {
+    const encoded = this.textEncoder.encode(text);
+    return crypto.webcrypto.subtle.encrypt(
+      {
+        name: 'RSA-OAEP'
+      },
+      publicKey,
+      encoded
+    );
+  }
+
+  /**
+   * Asynchronously generates an RSA-OAEP key pair with the SHA-512 hash
+   * algorithm. The modulus length is 4096 bits, and the public exponent
+   * is 0x010001 (65537). The generated keys are extractable and can be
+   * used for encryption and decryption.
+   */
+  async generateKeyPair(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
+    const { privateKey, publicKey } = await crypto.webcrypto.subtle.generateKey(
+      {
+        hash: 'SHA-512',
+        modulusLength: 4096,
+        name: 'RSA-OAEP',
+        publicExponent: new Uint8Array([1, 0, 1])
+      },
+      true,
+      ['encrypt', 'decrypt']
+    );
+    return { privateKey, publicKey };
   }
 
   hash(source: string) {

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from './crypto.config';
+import { EncryptedData } from './crypto.utils';
 
 @Injectable()
 export class CryptoService {
@@ -17,31 +18,31 @@ export class CryptoService {
   }
 
   /**
-   * Decrypts an Buffer using the provided private key.
+   * Decrypts the encrypted data using the provided private key.
    *
-   * @param buffer - The data to be decrypted.
+   * @param data - The data to be decrypted.
    * @param privateKey - The private key to be used for decryption.
    * @returns A promise that resolves to the decrypted string.
    */
-  async decrypt(buffer: Buffer, privateKey: CryptoKey): Promise<string> {
+  async decrypt(data: EncryptedData, privateKey: CryptoKey): Promise<string> {
     const decrypted = await crypto.webcrypto.subtle.decrypt(
       {
         name: 'RSA-OAEP'
       },
       privateKey,
-      buffer
+      data
     );
     return this.textDecoder.decode(decrypted);
   }
 
   /**
-   * Encrypts a string using the provided public key.
+   * Encrypts a string using the provided public key
    *
    * @param text - The text to be encrypted.
    * @param publicKey - The public key to be used for encryption.
-   * @return A promise that resolves to the encrypted data in Buffer format.
+   * @return A promise that resolves to the encrypted data
    */
-  async encrypt(text: string, publicKey: CryptoKey): Promise<Buffer> {
+  async encrypt(text: string, publicKey: CryptoKey): Promise<EncryptedData> {
     const encoded = this.textEncoder.encode(text);
     const arrayBuffer = await crypto.webcrypto.subtle.encrypt(
       {
@@ -50,7 +51,7 @@ export class CryptoService {
       publicKey,
       encoded
     );
-    return Buffer.from(arrayBuffer);
+    return new EncryptedData(arrayBuffer);
   }
 
   /**

--- a/packages/nestjs/src/modules/crypto/crypto.utils.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.utils.ts
@@ -1,0 +1,13 @@
+export class EncryptedData extends Uint8Array {
+  constructor(buffer: ArrayBufferLike) {
+    super(buffer);
+  }
+
+  toArray() {
+    return Array.from(this);
+  }
+
+  toJSON() {
+    return this.toArray();
+  }
+}

--- a/packages/nestjs/src/modules/crypto/index.ts
+++ b/packages/nestjs/src/modules/crypto/index.ts
@@ -1,3 +1,4 @@
 export * from './crypto.config';
 export * from './crypto.module';
 export * from './crypto.service';
+export * from './crypto.utils';


### PR DESCRIPTION
Adds the following methods to `CryptoService`:
- `generateKeyPair`: Asynchronously generates an RSA-OAEP key pair with the SHA-512 hash algorithm. The modulus length is 4096 bits, and the public exponent is 0x010001 (65537). The generated keys are extractable and can be used for encryption and decryption.
- `encrypt`: Encrypts plain text using the provided public key.
- `decrypt`: Decrypts an `ArrayBuffer` using the provided private key.