### PR TITLE
add AsymmetricEncryptionKeyPair and SerializableUint8Array

### DIFF
--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions, EncryptedData } from '..';
+import { AsymmetricEncryptionKeyPair, CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions, EncryptedData } from '..';
 import { CryptoService } from '../crypto.service';
 
 describe('CryptoService', () => {
@@ -57,12 +57,22 @@ describe('CryptoService', () => {
   });
 
   describe('generateKeyPair', () => {
-    it('should generate a key pair with private and public keys', async () => {
-      const keyPair = await cryptoService.generateKeyPair();
+    let keyPair: AsymmetricEncryptionKeyPair;
+
+    beforeEach(async () => {
+      keyPair = await cryptoService.generateKeyPair();
+    });
+
+    it('should generate a key pair with private and public keys', () => {
       expect(keyPair).toHaveProperty('privateKey');
       expect(keyPair).toHaveProperty('publicKey');
+    });
+    it('should have private and public keys that are instances of CryptoKey', () => {
       expect(keyPair.privateKey).toBeInstanceOf(CryptoKey);
       expect(keyPair.publicKey).toBeInstanceOf(CryptoKey);
+    });
+    it('should return an instance of AsymmetricEncryptionKeyPair', () => {
+      expect(keyPair).toBeInstanceOf(AsymmetricEncryptionKeyPair);
     });
   });
 

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.service.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { AsymmetricEncryptionKeyPair, CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions, EncryptedData } from '..';
+import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from '../crypto.config';
 import { CryptoService } from '../crypto.service';
+import { AsymmetricEncryptionKeyPair, SerializableUint8Array } from '../crypto.utils';
 
 describe('CryptoService', () => {
   let cryptoService: CryptoService;
@@ -78,29 +79,44 @@ describe('CryptoService', () => {
 
   describe('encrypt and decrypt', () => {
     const originalText = 'Cela devrait fonctionner avec les caractères unicode 😃';
-    let publicKey: CryptoKey, privateKey: CryptoKey;
+    let keyPair: AsymmetricEncryptionKeyPair;
 
     beforeEach(async () => {
-      const keyPair = await cryptoService.generateKeyPair();
-      publicKey = keyPair.publicKey;
-      privateKey = keyPair.privateKey;
+      keyPair = await cryptoService.generateKeyPair();
     });
 
-    it('encrypt should return an instance of EncryptedData', async () => {
-      const encrypted = await cryptoService.encrypt(originalText, publicKey);
-      expect(encrypted).toBeInstanceOf(EncryptedData);
+    it('encrypt should return an instance of SerializableUint8Array', async () => {
+      const encrypted = await cryptoService.encrypt(originalText, keyPair.publicKey);
+      expect(encrypted).toBeInstanceOf(SerializableUint8Array);
     });
 
     it('decrypt should return original text', async () => {
-      const encrypted = await cryptoService.encrypt(originalText, publicKey);
-      const decrypted = await cryptoService.decrypt(encrypted, privateKey);
+      const encrypted = await cryptoService.encrypt(originalText, keyPair.publicKey);
+      const decrypted = await cryptoService.decrypt(encrypted, keyPair.privateKey);
       expect(decrypted).toBe(originalText);
     });
 
     it('decrypt with incorrect private key should fail', async () => {
-      const encrypted = await cryptoService.encrypt(originalText, publicKey);
-      const keyPair = await cryptoService.generateKeyPair();
-      expect(cryptoService.decrypt(encrypted, keyPair.privateKey)).rejects.toThrow();
+      const encrypted = await cryptoService.encrypt(originalText, keyPair.publicKey);
+      const newKeyPair = await cryptoService.generateKeyPair();
+      expect(cryptoService.decrypt(encrypted, newKeyPair.privateKey)).rejects.toThrow();
+    });
+  });
+
+  describe('integration with AsymmetricEncryptionKeyPair', () => {
+    const originalText = 'Cela devrait fonctionner avec les caractères unicode 😃';
+    let keyPair: AsymmetricEncryptionKeyPair;
+
+    beforeEach(async () => {
+      keyPair = await cryptoService.generateKeyPair();
+    });
+
+    it('should be able to encrypt data, export the key, import the key, and decode the data', async () => {
+      const encrypted = await cryptoService.encrypt(originalText, keyPair.publicKey);
+      const rawKeyPair = await keyPair.export();
+      const importedKeyPair = await AsymmetricEncryptionKeyPair.fromRaw(rawKeyPair);
+      const decrypted = await cryptoService.decrypt(encrypted, importedKeyPair.privateKey);
+      expect(decrypted).toBe(originalText);
     });
   });
 });

--- a/packages/nestjs/src/modules/crypto/__tests__/crypto.utils.test.ts
+++ b/packages/nestjs/src/modules/crypto/__tests__/crypto.utils.test.ts
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+import { AsymmetricEncryptionKeyPair, SerializableUint8Array } from '../crypto.utils';
+
+describe('SerializableUint8Array', () => {
+  it('should correctly wrap an ArrayBufferLike object', () => {
+    const buffer = new ArrayBuffer(8);
+    const uint8Array = new SerializableUint8Array(buffer);
+    expect(uint8Array.buffer).toBe(buffer);
+  });
+
+  it('toArray returns an array with correct elements', () => {
+    const serializableArray = new SerializableUint8Array([1, 2, 3]);
+    expect(serializableArray.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('toJSON returns an array similar to toArray', () => {
+    const buffer = new Uint8Array([4, 5, 6]);
+    const serializableArray = new SerializableUint8Array(buffer);
+    expect(serializableArray.toJSON()).toEqual(serializableArray.toArray());
+  });
+});
+
+describe('AsymmetricEncryptionKeyPair', () => {
+  let keyPair: AsymmetricEncryptionKeyPair;
+
+  beforeAll(async () => {
+    keyPair = await AsymmetricEncryptionKeyPair.generate();
+  });
+
+  describe('generate', () => {
+    it('should create a privateKey and publicKey, which are instances of CryptoKeys', () => {
+      expect(keyPair.privateKey).toBeInstanceOf(CryptoKey);
+      expect(keyPair.publicKey).toBeInstanceOf(CryptoKey);
+    });
+    it('should return an AsymmetricEncryptionKeyPair instance', () => {
+      expect(keyPair).toBeInstanceOf(AsymmetricEncryptionKeyPair);
+    });
+  });
+
+  describe('fromRaw', () => {
+    it('should create an AsymmetricEncryptionKeyPair instance', async () => {
+      const rawKeyPair = await keyPair.export();
+      const newKeyPair = await AsymmetricEncryptionKeyPair.fromRaw(rawKeyPair);
+      expect(newKeyPair).toBeInstanceOf(AsymmetricEncryptionKeyPair);
+      expect(newKeyPair.privateKey).toBeInstanceOf(CryptoKey);
+      expect(newKeyPair.publicKey).toBeInstanceOf(CryptoKey);
+    });
+  });
+
+  describe('export', () => {
+    it('should return RawAsymmetricEncryptionKeyPair', async () => {
+      const rawKeyPair = await keyPair.export();
+      expect(rawKeyPair).toHaveProperty('privateKey');
+      expect(rawKeyPair).toHaveProperty('publicKey');
+      expect(rawKeyPair.privateKey).toBeInstanceOf(SerializableUint8Array);
+      expect(rawKeyPair.publicKey).toBeInstanceOf(SerializableUint8Array);
+    });
+  });
+
+  describe('export and fromRaw', () => {
+    it('should be able to continuously convert between formats ', async () => {
+      const exportedKeys = await keyPair.export();
+      const importedKeys = await AsymmetricEncryptionKeyPair.fromRaw(exportedKeys);
+      const reexportedKeys = await importedKeys.export();
+      expect(exportedKeys).toMatchObject(reexportedKeys);
+    });
+  });
+});

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from './crypto.config';
-import { EncryptedData } from './crypto.utils';
+import { AsymmetricEncryptionKeyPair, EncryptedData } from './crypto.utils';
 
 @Injectable()
 export class CryptoService {
@@ -60,7 +60,7 @@ export class CryptoService {
    * is 0x010001 (65537). The generated keys are extractable and can be
    * used for encryption and decryption.
    */
-  async generateKeyPair(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
+  async generateKeyPair(): Promise<AsymmetricEncryptionKeyPair> {
     const { privateKey, publicKey } = await crypto.webcrypto.subtle.generateKey(
       {
         hash: 'SHA-512',
@@ -71,7 +71,7 @@ export class CryptoService {
       true,
       ['encrypt', 'decrypt']
     );
-    return { privateKey, publicKey };
+    return new AsymmetricEncryptionKeyPair({ privateKey, publicKey });
   }
 
   hash(source: string) {

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -61,17 +61,7 @@ export class CryptoService {
    * used for encryption and decryption.
    */
   async generateKeyPair(): Promise<AsymmetricEncryptionKeyPair> {
-    const { privateKey, publicKey } = await crypto.webcrypto.subtle.generateKey(
-      {
-        hash: 'SHA-512',
-        modulusLength: 4096,
-        name: 'RSA-OAEP',
-        publicExponent: new Uint8Array([1, 0, 1])
-      },
-      true,
-      ['encrypt', 'decrypt']
-    );
-    return new AsymmetricEncryptionKeyPair({ privateKey, publicKey });
+    return AsymmetricEncryptionKeyPair.generate();
   }
 
   hash(source: string) {

--- a/packages/nestjs/src/modules/crypto/crypto.service.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.service.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CRYPTO_MODULE_OPTIONS_TOKEN, type CryptoModuleOptions } from './crypto.config';
-import { AsymmetricEncryptionKeyPair, EncryptedData } from './crypto.utils';
+import { AsymmetricEncryptionKeyPair, SerializableUint8Array } from './crypto.utils';
 
 @Injectable()
 export class CryptoService {
@@ -24,7 +24,7 @@ export class CryptoService {
    * @param privateKey - The private key to be used for decryption.
    * @returns A promise that resolves to the decrypted string.
    */
-  async decrypt(data: EncryptedData, privateKey: CryptoKey): Promise<string> {
+  async decrypt(data: Uint8Array, privateKey: CryptoKey): Promise<string> {
     const decrypted = await crypto.webcrypto.subtle.decrypt(
       {
         name: 'RSA-OAEP'
@@ -42,7 +42,7 @@ export class CryptoService {
    * @param publicKey - The public key to be used for encryption.
    * @return A promise that resolves to the encrypted data
    */
-  async encrypt(text: string, publicKey: CryptoKey): Promise<EncryptedData> {
+  async encrypt(text: string, publicKey: CryptoKey): Promise<SerializableUint8Array> {
     const encoded = this.textEncoder.encode(text);
     const arrayBuffer = await crypto.webcrypto.subtle.encrypt(
       {
@@ -51,7 +51,7 @@ export class CryptoService {
       publicKey,
       encoded
     );
-    return new EncryptedData(arrayBuffer);
+    return new SerializableUint8Array(arrayBuffer);
   }
 
   /**

--- a/packages/nestjs/src/modules/crypto/crypto.utils.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.utils.ts
@@ -1,3 +1,40 @@
+import crypto from 'node:crypto';
+
+type EncryptionKey = {
+  export(): Promise<Uint8Array>;
+};
+
+type EncryptionKeyConstructor = {
+  import: (data: Uint8Array) => Promise<EncryptionKey>;
+  new (nativeKey: CryptoKey): EncryptionKey;
+};
+
+export const PublicKey: EncryptionKeyConstructor = class implements EncryptionKey {
+  constructor(public nativeKey: CryptoKey) {}
+
+  static async import(data: Uint8Array): Promise<EncryptionKey> {
+    return new this(
+      await crypto.webcrypto.subtle.importKey('spki', data, { name: 'RSA-OAEP' }, true, ['encrypt', 'decrypt'])
+    );
+  }
+  async export(): Promise<Uint8Array> {
+    return new Uint8Array(await crypto.webcrypto.subtle.exportKey('spki', this.nativeKey));
+  }
+};
+
+export const PrivateKey: EncryptionKeyConstructor = class implements EncryptionKey {
+  constructor(public nativeKey: CryptoKey) {}
+
+  static async import(data: Uint8Array): Promise<EncryptionKey> {
+    return new this(
+      await crypto.webcrypto.subtle.importKey('pkcs8', data, { name: 'RSA-OAEP' }, true, ['encrypt', 'decrypt'])
+    );
+  }
+  async export(): Promise<Uint8Array> {
+    return new Uint8Array(await crypto.webcrypto.subtle.exportKey('pkcs8', this.nativeKey));
+  }
+};
+
 export class EncryptedData extends Uint8Array {
   constructor(buffer: ArrayBufferLike) {
     super(buffer);

--- a/packages/nestjs/src/modules/crypto/crypto.utils.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.utils.ts
@@ -1,38 +1,91 @@
-import crypto from 'node:crypto';
+function arrayBufferToString(buffer: ArrayBuffer): string {
+  return String.fromCharCode.apply(null, Array.from(new Uint8Array(buffer)));
+}
 
-export type RawAsymmetricEncryptionKeyPair = {
-  privateKey: Uint8Array;
-  publicKey: Uint8Array;
+function stringToArrayBuffer(str: string): ArrayBuffer {
+  const buf = new ArrayBuffer(str.length);
+  const bufView = new Uint8Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
+export type ExportedAsymmetricEncryptionKeyPair = {
+  privateKey: string;
+  publicKey: string;
 };
 
 export class AsymmetricEncryptionKeyPair {
   privateKey: CryptoKey;
   publicKey: CryptoKey;
 
+  private static algorithm = {
+    hash: 'SHA-512',
+    modulusLength: 4096,
+    name: 'RSA-OAEP',
+    publicExponent: new Uint8Array([1, 0, 1])
+  };
+
+  private static privateKeyPemFooter = '-----END PRIVATE KEY-----';
+  private static privateKeyPemHeader = '-----BEGIN PRIVATE KEY-----';
+  private static publicKeyPemFooter = '-----END PUBLIC KEY-----';
+  private static publicKeyPemHeader = '-----BEGIN PUBLIC KEY-----';
+
   constructor({ privateKey, publicKey }: { privateKey: CryptoKey; publicKey: CryptoKey }) {
     this.privateKey = privateKey;
     this.publicKey = publicKey;
   }
 
-  static async import({ privateKey, publicKey }: RawAsymmetricEncryptionKeyPair) {
-    return new this({
-      privateKey: await crypto.webcrypto.subtle.importKey('pkcs8', privateKey, { name: 'RSA-OAEP' }, true, [
-        'encrypt',
-        'decrypt'
-      ]),
-      publicKey: await crypto.webcrypto.subtle.importKey('spki', publicKey, { name: 'RSA-OAEP' }, true, [
-        'encrypt',
-        'decrypt'
-      ])
-    });
-  }
-
-  async export(): Promise<RawAsymmetricEncryptionKeyPair> {
+  static async fromRaw({ privateKey }: { privateKey: string; publicKey: string }) {
     return {
-      privateKey: new Uint8Array(await crypto.webcrypto.subtle.exportKey('pkcs8', this.privateKey)),
-      publicKey: new Uint8Array(await crypto.webcrypto.subtle.exportKey('spki', this.publicKey))
+      privateKey: await this.importPrivateKey(privateKey)
     };
   }
+
+  static async generate() {
+    const { privateKey, publicKey } = await globalThis.crypto.subtle.generateKey(this.algorithm, true, [
+      'encrypt',
+      'decrypt'
+    ]);
+    return new this({ privateKey, publicKey });
+  }
+
+  private static async importPrivateKey(pem: string) {
+    const pemContents = pem.substring(this.privateKeyPemHeader.length, pem.length - this.privateKeyPemFooter.length);
+    const decoded = atob(pemContents);
+    const buffer = stringToArrayBuffer(decoded);
+    return globalThis.crypto.subtle.importKey('pkcs8', buffer, this.algorithm, true, ['decrypt']);
+  }
+
+  async export(): Promise<{ privateKey: string; publicKey: string }> {
+    return {
+      privateKey: await this.exportPrivateKey(this.privateKey),
+      publicKey: await this.exportPublicKey(this.publicKey)
+    };
+  }
+
+  private async exportPrivateKey(key: CryptoKey) {
+    const exported = await globalThis.crypto.subtle.exportKey('pkcs8', key);
+    const exportedAsString = arrayBufferToString(exported);
+    const exportedAsBase64 = btoa(exportedAsString);
+    return [this.static.privateKeyPemHeader, exportedAsBase64, this.static.privateKeyPemFooter].join('\n');
+  }
+
+  private async exportPublicKey(key: CryptoKey) {
+    const exported = await globalThis.crypto.subtle.exportKey('spki', key);
+    const exportedAsString = arrayBufferToString(exported);
+    const exportedAsBase64 = btoa(exportedAsString);
+    return [this.static.publicKeyPemHeader, exportedAsBase64, this.static.publicKeyPemFooter].join('\n');
+  }
+
+  private get static() {
+    return AsymmetricEncryptionKeyPair;
+  }
+
+  // private toPem(content: string, label: string) {
+  //   return `-----BEGIN ${label}-----\n${content}\n-----END PUBLIC KEY-----`;
+  // }
 }
 
 export class EncryptedData extends Uint8Array {

--- a/packages/nestjs/src/modules/crypto/crypto.utils.ts
+++ b/packages/nestjs/src/modules/crypto/crypto.utils.ts
@@ -1,19 +1,20 @@
-function arrayBufferToString(buffer: ArrayBuffer): string {
-  return String.fromCharCode.apply(null, Array.from(new Uint8Array(buffer)));
-}
-
-function stringToArrayBuffer(str: string): ArrayBuffer {
-  const buf = new ArrayBuffer(str.length);
-  const bufView = new Uint8Array(buf);
-  for (let i = 0, strLen = str.length; i < strLen; i++) {
-    bufView[i] = str.charCodeAt(i);
+export class SerializableUint8Array extends Uint8Array {
+  constructor(array: ArrayBufferLike | ArrayLike<number>) {
+    super(array);
   }
-  return buf;
+
+  toArray() {
+    return Array.from(this);
+  }
+
+  toJSON() {
+    return this.toArray();
+  }
 }
 
-export type ExportedAsymmetricEncryptionKeyPair = {
-  privateKey: string;
-  publicKey: string;
+export type RawAsymmetricEncryptionKeyPair = {
+  privateKey: SerializableUint8Array;
+  publicKey: SerializableUint8Array;
 };
 
 export class AsymmetricEncryptionKeyPair {
@@ -27,23 +28,22 @@ export class AsymmetricEncryptionKeyPair {
     publicExponent: new Uint8Array([1, 0, 1])
   };
 
-  private static privateKeyPemFooter = '-----END PRIVATE KEY-----';
-  private static privateKeyPemHeader = '-----BEGIN PRIVATE KEY-----';
-  private static publicKeyPemFooter = '-----END PUBLIC KEY-----';
-  private static publicKeyPemHeader = '-----BEGIN PUBLIC KEY-----';
-
   constructor({ privateKey, publicKey }: { privateKey: CryptoKey; publicKey: CryptoKey }) {
     this.privateKey = privateKey;
     this.publicKey = publicKey;
   }
 
-  static async fromRaw({ privateKey }: { privateKey: string; publicKey: string }) {
-    return {
-      privateKey: await this.importPrivateKey(privateKey)
-    };
+  static async fromRaw({
+    privateKey,
+    publicKey
+  }: RawAsymmetricEncryptionKeyPair): Promise<AsymmetricEncryptionKeyPair> {
+    return new this({
+      privateKey: await this.importPrivateKey(privateKey),
+      publicKey: await this.importPublicKey(publicKey)
+    });
   }
 
-  static async generate() {
+  static async generate(): Promise<AsymmetricEncryptionKeyPair> {
     const { privateKey, publicKey } = await globalThis.crypto.subtle.generateKey(this.algorithm, true, [
       'encrypt',
       'decrypt'
@@ -51,14 +51,15 @@ export class AsymmetricEncryptionKeyPair {
     return new this({ privateKey, publicKey });
   }
 
-  private static async importPrivateKey(pem: string) {
-    const pemContents = pem.substring(this.privateKeyPemHeader.length, pem.length - this.privateKeyPemFooter.length);
-    const decoded = atob(pemContents);
-    const buffer = stringToArrayBuffer(decoded);
-    return globalThis.crypto.subtle.importKey('pkcs8', buffer, this.algorithm, true, ['decrypt']);
+  private static async importPrivateKey(rawKey: Uint8Array): Promise<CryptoKey> {
+    return globalThis.crypto.subtle.importKey('pkcs8', rawKey, this.algorithm, true, ['decrypt']);
   }
 
-  async export(): Promise<{ privateKey: string; publicKey: string }> {
+  private static async importPublicKey(rawKey: Uint8Array): Promise<CryptoKey> {
+    return globalThis.crypto.subtle.importKey('spki', rawKey, this.algorithm, true, ['encrypt']);
+  }
+
+  async export(): Promise<RawAsymmetricEncryptionKeyPair> {
     return {
       privateKey: await this.exportPrivateKey(this.privateKey),
       publicKey: await this.exportPublicKey(this.publicKey)
@@ -66,38 +67,10 @@ export class AsymmetricEncryptionKeyPair {
   }
 
   private async exportPrivateKey(key: CryptoKey) {
-    const exported = await globalThis.crypto.subtle.exportKey('pkcs8', key);
-    const exportedAsString = arrayBufferToString(exported);
-    const exportedAsBase64 = btoa(exportedAsString);
-    return [this.static.privateKeyPemHeader, exportedAsBase64, this.static.privateKeyPemFooter].join('\n');
+    return new SerializableUint8Array(await globalThis.crypto.subtle.exportKey('pkcs8', key));
   }
 
   private async exportPublicKey(key: CryptoKey) {
-    const exported = await globalThis.crypto.subtle.exportKey('spki', key);
-    const exportedAsString = arrayBufferToString(exported);
-    const exportedAsBase64 = btoa(exportedAsString);
-    return [this.static.publicKeyPemHeader, exportedAsBase64, this.static.publicKeyPemFooter].join('\n');
-  }
-
-  private get static() {
-    return AsymmetricEncryptionKeyPair;
-  }
-
-  // private toPem(content: string, label: string) {
-  //   return `-----BEGIN ${label}-----\n${content}\n-----END PUBLIC KEY-----`;
-  // }
-}
-
-export class EncryptedData extends Uint8Array {
-  constructor(buffer: ArrayBufferLike) {
-    super(buffer);
-  }
-
-  toArray() {
-    return Array.from(this);
-  }
-
-  toJSON() {
-    return this.toArray();
+    return new SerializableUint8Array(await globalThis.crypto.subtle.exportKey('spki', key));
   }
 }


### PR DESCRIPTION
Add new classes `SerializableUint8Array` (replaces `EncryptedData`) and `AsymmetricEncryptionKeyPair`. The `CryptoService` operates on instances of`AsymmetricEncryptionKeyPair`, which can be exported to `RawAsymmetricEncryptionKeyPair`, which contains the public and private keys encoded as type `SerializableUint8Array`. The `SerializableUint8Array` class extends the standard `Uint8Array` so that `JSON.stringify` will result in it being converted to `number[]`.